### PR TITLE
Stopes liking suggested sponsored posts.

### DIFF
--- a/casperjs/loveMachine.js
+++ b/casperjs/loveMachine.js
@@ -154,7 +154,7 @@ var doSomeLove = function () {
 
                         if( $(this).attr('id') === undefined || $(this).attr('id') === "" ){
 							// If element doesn't have class "selected", which means it's already clicked
-							if ( !$(this).children('strong').hasClass('selected') && window.likePosts){ 
+		if ( !$(this).children('strong').hasClass('selected') && window.likePosts &&  $(this).attr("href").indexOf("Aei") == -1){ 
                                 $(this).attr('id', 'like' + window.nbPostLikes );
                                 console.log('Creating id="#like' + window.nbPostLikes + '"' );
                                 window.nbPostLikes++;


### PR DESCRIPTION
I don't know if you want suggested posts to be liked, but to me it does not seem like it benefits anyone besides facebook. I want to make the option to only like pages or people but i can't figure out how to navigate from the footer to get information from the header.... yet. Made some progress on the poke bomb today as well, i'm going to make a github page for it soon.  This is so exciting.
